### PR TITLE
Avoid deprecation warning: use this.getHeaders from node v12+

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -196,9 +196,18 @@ module.exports = (function () {
                 return ret;
               }
 
+              /** Get content type header **/
+              var contentType;
+
+              try {
+                contentType = this.getHeaders()['content-type']; // method added in node v7.7.0
+              } catch (err) {
+                contentType = this._headers['content-type']; // required for pre node v7.7.0 [deprecated since v12.0.0]
+              }
+
               /** Create the new cache **/
               self.add(name, body, {
-                  type: this._headers['content-type'],
+                  type: contentType,
                   status: this.statusCode,
                   expire: expirationPolicy(req, res)
                 },


### PR DESCRIPTION
## Issue

Node version 12 deprecated OutgoingMessage.prototype._headers, which is used to create cache route.

The line using this._headers:
./node_modules/express-redis-cache/lib/ExpressRedisCache/route.js:200:30

Instead of using this._headers, we need to use obj.getHeaders() to get the headers object.

So we should replace the property name ._headers with the function .getHeaders(). Same results using either one except using the function is the supported method and removes the deprecation warning.

## Pull Request
I used try/catch to make this compatible with all node versions.

```js
try {
  contentType = this.getHeaders()['content-type']; // method added in node v7.7.0
} catch (err) {
  contentType = this._headers['content-type']; // required by pre v7.7.0 node [deprecated since v12.0.0]
}
```