### PR TITLE
Fix deprecated warning related to res.status

### DIFF
--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -167,7 +167,7 @@ module.exports = (function () {
 
           if ( cache.length &&  cache[0].body != null ) {
             res.contentType(cache[0].type || "text/html");
-            res.status(cache[0].status);
+            res.status(parseInt(cache[0].status));
             if(binary){ //Convert back to binary buffer
               res.send(new Buffer(cache[0].body, 'base64'));
             }else{


### PR DESCRIPTION
Fix this warning: `express deprecated res.status("200"): use res.status(200) instead at node_modules/express-redis-cache-next/lib/ExpressRedisCache/route.js:170:17`